### PR TITLE
CONTRIBUTING.mdにブランチ戦略を記載する

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 - LGTM Factory では、シンプルかつ柔軟なワークフローで、チーム開発の効率化を実現するため、[GitHub Flow](https://docs.github.com/ja/get-started/using-github/github-flow) を採用します。
 - main ブランチから各自ブランチを作成し、作業を開始してください。
 - ブランチ作成時のコマンド:
-  - `git branch -c ブランチ名`
+  - `git switch -c ブランチ名`
 
 ## ブランチ名のフォーマット
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+## ブランチ戦略について
+
+- LGTM Factory では、シンプルかつ柔軟なワークフローで、チーム開発の効率化を実現するため、[GitHub Flow](https://docs.github.com/ja/get-started/using-github/github-flow) を採用します。
+- main ブランチから各自ブランチを作成し、作業を開始してください。
+- ブランチ作成時のコマンド:
+  - `git branch -c ブランチ名`
+
+## ブランチ名のフォーマット
+
+- `<Title>-<Issue Number>`
+- イシュー番号 123 にて、ログイン機能を追加する例: `add-login-function-123`
+- Title はイシューのタイトルを端的に要約し、英語で記述してください。
+
+### 注意点
+
+- 特殊文字を含まないブランチ名を作成してください。
+- ブランチ名は文字で始める必要があります。
+- 安全に使用できる文字セットは以下の通りです。
+  - 英語のアルファベット (a から z、A から Z)
+  - 数字 (0 から 9)
+  - 限定された句読点文字のセット:
+    - ピリオド (.)
+    - ハイフン (-)
+    - アンダースコア (\_)
+    - スラッシュ (/)
+- 参考: [ブランチとタグの名前付け -GitHub Docs](https://docs.github.com/ja/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags)
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,14 @@
 
 - LGTM Factory では、シンプルかつ柔軟なワークフローで、チーム開発の効率化を実現するため、[GitHub Flow](https://docs.github.com/ja/get-started/using-github/github-flow) を採用します。
 - main ブランチから各自ブランチを作成し、作業を開始してください。
+
+## ブランチに関するコマンド
+
 - ブランチ作成時のコマンド:
+  - `git branch ブランチ名`
+- ブランチを移動するコマンド:
+  - `git switch ブランチ名`
+- ブランチ作成とブランチ移動を同時に行うコマンド:
   - `git switch -c ブランチ名`
 
 ## ブランチ名のフォーマット

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-## ブランチ戦略について
+# ブランチについて
+
+## ブランチ戦略とは
 
 - LGTM Factory では、シンプルかつ柔軟なワークフローで、チーム開発の効率化を実現するため、[GitHub Flow](https://docs.github.com/ja/get-started/using-github/github-flow) を採用します。
 - main ブランチから各自ブランチを作成し、作業を開始してください。
@@ -25,8 +27,9 @@
     - スラッシュ (/)
 - 参考: [ブランチとタグの名前付け -GitHub Docs](https://docs.github.com/ja/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags)
 
+# コミットメッセージについて
 
-# フォーマット  
+## フォーマット  
 [Semantic Commit Massage](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)を採用します
 
 - フォーマット: `<Type>: <Emoji> #<Issue Number> <Title>`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # ブランチについて
 
-## ブランチ戦略とは
+## ブランチ戦略について
 
 - LGTM Factory では、シンプルかつ柔軟なワークフローで、チーム開発の効率化を実現するため、[GitHub Flow](https://docs.github.com/ja/get-started/using-github/github-flow) を採用します。
 - main ブランチから各自ブランチを作成し、作業を開始してください。
@@ -39,7 +39,7 @@
 - Emojiは任意
 - Description（スリーライン）は任意  
 
-## Type, Emoji
+### Type, Emoji
 
 - どんなコミットなのかシュッと分かるようにPrefixとしてコミットの種別を書きます  
 - Semantic Commit Messageと同様の種別を使います  
@@ -61,7 +61,7 @@
 - test 🧪  
   - テストコードの追加や修正
 
-## Issue Number
+### Issue Number
 
 - そのコミットに紐づくIssue番号を書きます  
   - リンクになって、トラッキングがしやすいため
@@ -71,16 +71,16 @@
 
 - なお、デフォルトの設定だと#がコメント扱いになるのでこの位置に置いています
 
-##  Subject
+###  Subject
 
 - いわゆる、変更内容を書きます
-### Title
+#### Title
 - 現在形で（「◯◯した」ではなく「◯◯する」）書くこととします
   - fyi: https://minus9d.hatenablog.com/entry/2014/02/11/125222
 - 文字数は特に制限しませんが、20〜30文字以内が適切だと思います
   - fyi: https://twitter.com/_mono/status/1240075582164983809
 
-### Description
+#### Description
 
 - Descriptionは必須ではありません
 


### PR DESCRIPTION
## 概要
CONTRIBUTING.mdにブランチ戦略を記載する

## 関連イシュー
#12 

## 備考
#### ブランチ戦略としてはGitHub Flowを採用する、としました！
理由は以下の通りです。

- シンプルなフローなためGitHubに慣れてない人でも使いやすいこと
- First Contributions JAでもGitHub Flowを採用しており、開発中特に問題がなかったため

ドキュメントの中でブランチ戦略について詳細に説明することは控え、リンクをしています。

#### ブランチ名のフォーマットについては[色々悩んだ結果](https://github.com/lgtm-factory/lgtm-factory/discussions/14)、`<タイトル>-<イシュー番号>` としました！
コミットメッセージと違ってイシュー番号に`#`がついてないのは、 [GitHub Docs](https://docs.github.com/ja/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags)に

> 安全に使用できる文字セット

として`#`が書かれていなかったためです。
また、タイトルとイシュー番号の順番がコミットメッセージと異なっているのも、

> ブランチ名は文字で始める必要があります。

とあったためです。

prefixなしの理由については、自分の、「必要ないなら削りたいの精神」からです😅
もし何か質問や指摘などありましたら、お気軽にお願いします！！🙏