### PR TITLE
議事録用のディスカッションテンプレートを作成

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/meeting-report.yml
+++ b/.github/DISCUSSION_TEMPLATE/meeting-report.yml
@@ -1,0 +1,41 @@
+title: "【第X回】2024年XX月XX日"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Here is English only?
+  - type: textarea
+    id: index
+    attributes:
+      label: 目次
+      value: |
+        目次はトピックを立てた人が書き加えてください
+        - [トピックタイトル](URL)
+        - 結論
+    validations:
+      required: true
+  - type: textarea
+    id: next-task
+    attributes:
+      label: 次の一週間でやること
+      value: |
+        - 
+        -
+    validations:
+      required: true
+  - type: textarea
+    id: format-for-topic
+    attributes:
+      label: トピック用フォーマット
+      value: |
+        以下をコピーしてトピックを立ててください
+        ```
+        ## 概要
+
+        ## 結論
+
+        ## 関連Issues, Discussions
+        <!-- あれば書いてください -->
+        ```
+    validations:
+      required: true


### PR DESCRIPTION
## チケットへのリンク
#42 

## やったこと

議事録用のディスカッションテンプレートを作成しました

以下、テスト用リポジトリでのテンプレートのスクショです📷
<img width="808" alt="スクリーンショット 2024-08-10 13 59 15" src="https://github.com/user-attachments/assets/2fd957cf-3461-4e1e-87d3-12f1bb2eb163">
<img width="842" alt="スクリーンショット 2024-08-10 13 59 35" src="https://github.com/user-attachments/assets/83e3c87d-2265-4347-8895-ec3f62ee5152">

## やらないこと

他のディスカッションテンプレートの作成
今後必要になったら作っても良いかも？

## できるようになること（ユーザ目線）

議事録をテンプレートをから作成できるようになる！簡単！

## できなくなること（ユーザ目線）

なし

## 動作確認

自分のテスト用リポジトリで確認しました
うまくいけば動くはず・・・！

## その他

textareaのrenderというkeyの値を指定しなければ、textareaでマークダウン使えるっぽいので、もしかしたら他のテンプレート用のファイルに関しても、mdファイルを使わなくても同様に記述できるかも？（今後の参考になれば！🙏）

参考：
https://docs.github.com/ja/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#textarea