### PR TITLE
サイトで使用するフォントを設定する

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,7 +64,6 @@
     @apply border-border;
   }
   body {
-    font-family: var(--font-inter), var(--font-notojp);
     @apply bg-background text-foreground;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,26 @@
 import type { Metadata } from "next";
-import { Inter, Noto_Sans_JP } from "next/font/google";
+import { IBM_Plex_Mono, Noto_Sans_JP, Monoton } from "next/font/google";
 import "./globals.css";
+import { cn } from "@/lib/shadcn-utils";
 
-
-const inter = Inter({
+const ibmMono = IBM_Plex_Mono({
+  weight: ["100", "200", "300", "400", "500", "600", "700"], // thinからboldまで指定可能
   subsets: ["latin"],
   display: "swap",
-  variable: "--font-inter",
+  variable: "--font-ibmMono",
 });
 
 const notojp = Noto_Sans_JP({
   preload: false,
   display: "swap",
   variable: "--font-notojp",
+});
+
+const monoton = Monoton({
+  weight: "400",
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-monoton",
 });
 
 export const metadata: Metadata = {
@@ -27,10 +35,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body className={`${inter.variable} ${notojp.variable}`}>
+      <body
+        className={cn(
+          ibmMono.variable,
+          notojp.variable,
+          monoton.variable,
+          "font-sans text-foreground",
+        )}
+      >
         <p className="text-4xl">
-          <span>LGTM</span>
-          <span>良さそうだね</span>
+          <span className="font-monoton text-accent">LGTM Factory</span>
+          <span className="font-thin">LGTM良さそうだね</span>
+          <span className="font-bold">LGTM良さそうだね</span>
         </p>
         {children}
       </body>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
 
 const config = {
   darkMode: ["class"],
@@ -18,6 +19,10 @@ const config = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ["var(--font-ibmMono), var(--font-notojp)", ...fontFamily.sans],
+        monoton: ["var(--font-monoton)", ...fontFamily.sans],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号

<!-- 例: close #36 -->

close #118 

## やったこと（変更点）
- IBM Plex MonoとMonotonのインポートとセットアップ

<!-- このプルリクで何をしたのか？ -->

## できるようになること（ユーザ目線）
- 欧文はIBM Plex Sans, 和文はNoto Sans JPで表示される
- `className`に`font-monoton`を追加すると、タイトルのフォントが使用できる

## 動作確認
ローカル環境で以下を確認
<img width="700" alt="スクリーンショット 2024-08-25 21 56 28" src="https://github.com/user-attachments/assets/14da5d02-ff51-412e-8303-b494ae91f8a9">

プレビューURLでも確認できます
https://86c13b9b.lgtm-factory.pages.dev/


<!-- どのような動作確認を行ったのか？　-->

## その他

今の設定のままだと、Monotonを使用する際に、`className={cn(monoton.className, "text-red-500...")}`とする必要があったので、使いやすいようにtailwind.config.jsを修正し、クラス名を`font-monoton`として設定しました！（もしかしたら、自分の調査不足かも）

他のフォントに関しても上記の設定方法と統一したかったので、これまでbodyクラスで指定していたCSS変数は削除し、クラス名を`font-sans`としました。

また、`font-monoton`クラスですが、`font-title`などの方が使いやすいと思いますか？
ご意見いただけたら幸いです！

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）　-->
