### PR TITLE
ロゴと背景画像をassetsに配置

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -601,6 +601,126 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz",
+      "integrity": "sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz",
+      "integrity": "sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz",
+      "integrity": "sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.5.tgz",
+      "integrity": "sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.5.tgz",
+      "integrity": "sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz",
+      "integrity": "sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
+      "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz",
+      "integrity": "sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { IBM_Plex_Mono, Noto_Sans_JP, Monoton } from "next/font/google";
 import "./globals.css";
 import { cn } from "@/lib/shadcn-utils";
+import Image from "next/image";
+import bgImage from "@/assets/bg-image.png";
 
 const ibmMono = IBM_Plex_Mono({
   weight: ["100", "200", "300", "400", "500", "600", "700"], // thinからboldまで指定可能
@@ -40,14 +42,19 @@ export default function RootLayout({
           ibmMono.variable,
           notojp.variable,
           monoton.variable,
-          "font-sans text-foreground",
+          "relative h-screen font-sans text-foreground",
         )}
       >
-        <p className="text-4xl">
-          <span className="font-monoton text-accent">LGTM Factory</span>
-          <span className="font-thin">LGTM良さそうだね</span>
-          <span className="font-bold">LGTM良さそうだね</span>
-        </p>
+        <div className="fixed inset-0 -z-10">
+          <Image
+            src={bgImage}
+            alt="background image"
+            fill
+            quality={100}
+            placeholder="blur"
+            className="object-cover"
+          />
+        </div>
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { Button } from "@/components/shadcn-ui/button";
+import Image from "next/image";
+import logoImage from "@/assets/logo.svg";
 
 export default function Home() {
   function copy(copyText: string) {
@@ -17,6 +19,57 @@ export default function Home() {
           download
         </a>
       </Button>
+      <div className="text-4xl">
+        <Image src={logoImage} width={180} alt="logo image" />
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-monoton text-accent">LGTM Factory</p>
+        <p className="font-thin">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p>
+      </div>
     </main>
   );
 }

--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -1,0 +1,5 @@
+<svg width="543" height="333" viewBox="0 0 543 333" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 333V105.007L464 156V333L0 333Z" fill="#FCD34D"/>
+<path d="M326 118.274L334.1 29H395.863L407 126L326 118.274Z" fill="#FCD34D"/>
+<path d="M434 129.595L446.224 0H509.383L522.626 137.32L543 333H485.953V134.745L434 129.595Z" fill="#FCD34D"/>
+</svg>


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号

<!-- 例: close #36 -->

close #124 

## やったこと（変更点）
- src/assetsディレクトリを作成
- assetsディレクトリにロゴと背景画像を配置
- layout.tsxにて、背景画像をスタイリング
- 背景画像が固定されていることを確認するため、確認用の文章をたくさん表示
- page.tsxにて、確認のためのロゴを配置

<!-- このプルリクで何をしたのか？ -->

## 動作確認
開発環境にて確認済み

<!-- どのような動作確認を行ったのか？　-->

## その他

結局、 #125 で色々調べた結果、srcディレクトリにassetsディレクトリを作成し、こちらに画像を置くことにしました。
理由としては、2点あります

### 1. 画像を静的importすると、簡単にplaceholderを使うことができる

背景画像は画面を占める割合が大きいので、読み込み時に真っ白になると見栄えが悪いなあと思います。
そのような問題を`placeholder="blur"`を指定することで、回避できるそうです。

  - 詳細： https://nextjs.org/docs/app/api-reference/components/image#placeholder
  - デモページ： https://image-component.nextjs.gallery/placeholder


### 2. デフォルトでキャッシュの設定が`public, max-age=315360000, immutable`になる

ユーザーが画面を更新してもキャッシュが効くため、サーバーへの無駄な問い合わせが減ります

---

もし今後不都合な点が出てきたら、柔軟にpublicディレクトリに変更したりできればと思います！

あと、別の話ですが、#125 で、LGTMデータに使用される画像データはpublicディレクトリに置いた方が良いかも？みたいなことを言いましたが、これも早計だったかも……

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）　-->
