### PR TITLE
feat: ✨ #91 クエリパラメーターのバリデーションを実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react-dom": "^18",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@cloudflare/next-on-pages": "^1.13.2",
@@ -9241,7 +9242,7 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-dom": "^18",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@cloudflare/next-on-pages": "^1.13.2",

--- a/src/app/api/v1/lgtm-images/_constants/index.ts
+++ b/src/app/api/v1/lgtm-images/_constants/index.ts
@@ -5,6 +5,7 @@ export const DEFAULT_VALUES = {
 };
 
 export const ERRORS = {
+  INVALID_INPUT_DATA: "Invalid input data",
   THEME_MISSING: "Theme is missing",
   INVALID_MODULE_STRUCTURE: "Invalid module structure",
   UNEXPECTED: "An unexpected error occurred",

--- a/src/app/api/v1/lgtm-images/_schemas/index.ts
+++ b/src/app/api/v1/lgtm-images/_schemas/index.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const inputDataSchema = z.object({
+  emoji: z.string().emoji(),
+  text: z.string(),
+  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
+});

--- a/src/app/api/v1/lgtm-images/_utils/index.ts
+++ b/src/app/api/v1/lgtm-images/_utils/index.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 import { ERRORS } from "../_constants";
 import { ImageResponse } from "next/og";
 import { GetLgtmData, InputData } from "@/types/lgtm-data";
+import { inputDataSchema } from "../_schemas";
 
 export function getSearchParams(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
@@ -16,6 +17,14 @@ export function getSearchParams(request: NextRequest) {
 
 export function handleMissingTheme(inputData: InputData) {
   return createErrorResponse(inputData, ERRORS.THEME_MISSING, 400);
+}
+
+export function validateInputData(inputData: InputData) {
+  return inputDataSchema.safeParse(inputData);
+}
+
+export function handleValidationError(inputData: InputData) {
+  return createErrorResponse(inputData, ERRORS.INVALID_INPUT_DATA, 400);
 }
 
 export async function importLgtmDataModule(

--- a/src/app/api/v1/lgtm-images/route.tsx
+++ b/src/app/api/v1/lgtm-images/route.tsx
@@ -6,6 +6,8 @@ import {
   getSearchParams,
   handleMissingTheme,
   handleError,
+  validateInputData,
+  handleValidationError,
 } from "./_utils";
 
 export const runtime = "edge";
@@ -22,6 +24,11 @@ export async function GET(request: NextRequest) {
   // テーマが入力されなかった場合
   if (!theme) {
     return handleMissingTheme(inputData);
+  }
+
+  const validationResult = validateInputData(inputData);
+  if (!validationResult.success) {
+    return handleValidationError(inputData);
   }
 
   try {


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号

<!-- 例: close #36 -->

close #91 

## やったこと（変更点）
- zodのインストール
- zodスキーマの作成
  - _schemas/index.tsを作成したのですが、良かったでしょうか……？
- 他のエラーハンドリングにならって、`inputData`のバリデーション

<!-- このプルリクで何をしたのか？ -->

## やらないこと
- `theme`のバリデーション
  - テーマが入力されなかった場合と、テーマが存在しない場合でエラーをキャッチするので、必要ないと考えました
  - もし必要ある場合は、`inputData`と`theme`を別々に扱わず、`queryData`としてひとまとめにしても良いような気がしました

<!-- このプルリクでやらないことは何か（やらない場合は、どのタイミングでやるかを記載（不明なら書かなくてOK）） -->

## 動作確認
開発環境にて確認済み

<!-- どのような動作確認を行ったのか？　-->

## その他

`handleMissingTheme()`にならって`handleValidationError()`を作成したのですが、無駄に関数を増やしてしまった感じがしています。
`validateInputData()`の中でエラーを投げて、`importLgtmDataModule()`を含むtry/catch文に含ませても良いかなーと思ったのですが、どう思いますか……？
もし含ませる場合は、以下も含ませても良いかも……？
```ts
if (!theme) {
    return handleMissingTheme(inputData);
  }
```

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）　-->
