### PR TITLE
ヘッダーとフッターの実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lgtm-factory",
       "version": "0.1.0",
       "dependencies": {
+        "@icons-pack/react-simple-icons": "^10.0.0",
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.0",
@@ -356,6 +357,15 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@icons-pack/react-simple-icons": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-10.0.0.tgz",
+      "integrity": "sha512-oU0PVDx9sbNQjRxJN555dsHbRApYN+aBq/O9+wo3JgNkEfvBMgAEtsSGtXWWXQsLAxJcYiFOCzBWege/Xj/JFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@icons-pack/react-simple-icons": "^10.0.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout({
           ibmMono.variable,
           notojp.variable,
           monoton.variable,
-          "relative h-screen font-sans text-foreground",
+          "relative font-sans text-foreground",
         )}
       >
         <div className="fixed inset-0 -z-10">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -57,9 +57,11 @@ export default function RootLayout({
             className="object-cover"
           />
         </div>
-        <Header />
-        {children}
-        <Footer />
+        <div className="min-h-dvh">
+          <Header />
+          {children}
+          <Footer />
+        </div>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import "./globals.css";
 import { cn } from "@/lib/shadcn-utils";
 import Image from "next/image";
 import bgImage from "@/assets/bg-image.png";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 
 const ibmMono = IBM_Plex_Mono({
   weight: ["100", "200", "300", "400", "500", "600", "700"], // thinからboldまで指定可能
@@ -55,7 +57,9 @@ export default function RootLayout({
             className="object-cover"
           />
         </div>
+        <Header />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function Home() {
         <p className="font-monoton text-accent">LGTM Factory</p>
         <p className="font-thin">LGTM良さそうだね</p>
         <p className="font-bold">LGTM良さそうだね</p>
-        <p className="font-monoton text-accent">LGTM Factory</p>
+        {/* <p className="font-monoton text-accent">LGTM Factory</p>
         <p className="font-thin">LGTM良さそうだね</p>
         <p className="font-bold">LGTM良さそうだね</p>
         <p className="font-monoton text-accent">LGTM Factory</p>
@@ -68,7 +68,7 @@ export default function Home() {
         <p className="font-bold">LGTM良さそうだね</p>
         <p className="font-monoton text-accent">LGTM Factory</p>
         <p className="font-thin">LGTM良さそうだね</p>
-        <p className="font-bold">LGTM良さそうだね</p>
+        <p className="font-bold">LGTM良さそうだね</p> */}
       </div>
     </main>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,16 @@
+import Image from "next/image";
+import logoImage from "@/assets/logo.svg";
+
+export default function Footer() {
+  return (
+    <footer className="flex h-20 items-center justify-end gap-4 px-8 text-lg font-medium">
+      <Image
+        src={logoImage}
+        alt="logo image"
+        width={40}
+        className="-scale-x-100"
+      />
+      <span>LGTM Factory</span>
+    </footer>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,16 +1,10 @@
-import Image from "next/image";
-import logoImage from "@/assets/logo.svg";
+import LogoImage from "@/components/LogoImage";
 
 export default function Footer() {
   return (
-    <footer className="flex h-20 items-center justify-end gap-4 px-8 text-lg font-medium">
-      <Image
-        src={logoImage}
-        alt="logo image"
-        width={40}
-        className="-scale-x-100"
-      />
-      <span>LGTM Factory</span>
+    <footer className="sticky top-full flex h-32 items-center justify-end gap-8 px-9">
+      <LogoImage />
+      <span className="text-3xl font-medium">LGTM Factory</span>
     </footer>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,14 +22,12 @@ export default function Header() {
       <HeaderButton>
         <Link href="/">
           <LogoImage />
-          <span className="text-3xl">LGTM Factory</span>
         </Link>
       </HeaderButton>
 
       <HeaderButton>
         <a href={GITHUB_URL} target="_blank">
           <SiGithub size={40} />
-          <span className="text-3xl">Create new LGTM?</span>
         </a>
       </HeaderButton>
     </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,7 @@ function HeaderButton({ children }: { children: React.ReactNode }) {
 
 export default function Header() {
   return (
-    <header className="fixed flex h-20 w-full items-center justify-between px-8 text-lg font-medium">
+    <header className="sticky left-0 top-0 z-50 flex h-20 w-full items-center justify-between px-8 text-lg font-medium">
       <HeaderButton>
         <Link href="/">
           <Image

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,16 +1,15 @@
-import Image from "next/image";
 import Link from "next/link";
-import logoImage from "@/assets/logo.svg";
 import { SiGithub } from "@icons-pack/react-simple-icons";
 import { Button } from "@/components/shadcn-ui/button";
 import { GITHUB_URL } from "@/lib/constants";
+import LogoImage from "@/components/LogoImage";
 
 function HeaderButton({ children }: { children: React.ReactNode }) {
   return (
     <Button
       asChild
       variant="ghost"
-      className="flex items-center gap-4 px-0 text-lg hover:bg-transparent hover:opacity-60"
+      className="flex items-center gap-8 px-0 text-lg hover:bg-transparent hover:opacity-60"
     >
       {children}
     </Button>
@@ -19,23 +18,18 @@ function HeaderButton({ children }: { children: React.ReactNode }) {
 
 export default function Header() {
   return (
-    <header className="sticky left-0 top-0 z-50 flex h-20 w-full items-center justify-between px-8 text-lg font-medium">
+    <header className="sticky left-0 top-0 z-50 flex h-32 w-full items-center justify-between px-9 font-medium">
       <HeaderButton>
         <Link href="/">
-          <Image
-            src={logoImage}
-            alt="logo image"
-            width={40}
-            className="-scale-x-100"
-          />
-          <span>LGTM Factory</span>
+          <LogoImage />
+          <span className="text-3xl">LGTM Factory</span>
         </Link>
       </HeaderButton>
 
       <HeaderButton>
         <a href={GITHUB_URL} target="_blank">
-          <SiGithub />
-          <span>Create new LGTM ?</span>
+          <SiGithub size={40} />
+          <span className="text-3xl">Create new LGTM?</span>
         </a>
       </HeaderButton>
     </header>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import Link from "next/link";
+import logoImage from "@/assets/logo.svg";
+import { SiGithub } from "@icons-pack/react-simple-icons";
+import { Button } from "@/components/shadcn-ui/button";
+import { GITHUB_URL } from "@/lib/constants";
+
+function HeaderButton({ children }: { children: React.ReactNode }) {
+  return (
+    <Button
+      asChild
+      variant="ghost"
+      className="flex items-center gap-4 px-0 text-lg hover:bg-transparent hover:opacity-60"
+    >
+      {children}
+    </Button>
+  );
+}
+
+export default function Header() {
+  return (
+    <header className="fixed flex h-20 w-full items-center justify-between px-8 text-lg font-medium">
+      <HeaderButton>
+        <Link href="/">
+          <Image
+            src={logoImage}
+            alt="logo image"
+            width={40}
+            className="-scale-x-100"
+          />
+          <span>LGTM Factory</span>
+        </Link>
+      </HeaderButton>
+
+      <HeaderButton>
+        <a href={GITHUB_URL} target="_blank">
+          <SiGithub />
+          <span>Create new LGTM ?</span>
+        </a>
+      </HeaderButton>
+    </header>
+  );
+}

--- a/src/components/LogoImage.tsx
+++ b/src/components/LogoImage.tsx
@@ -1,0 +1,22 @@
+import Image from "next/image";
+import logoImage from "@/assets/logo.svg";
+import { cn } from "@/lib/shadcn-utils";
+
+export default function LogoImage({
+  width = 72,
+  className,
+}: {
+  width?: number;
+  className?: string;
+}) {
+  return (
+    <span className="inline-block align-bottom">
+      <Image
+        src={logoImage}
+        alt="LGTM logo image"
+        width={width}
+        className={cn("-translate-y-1.5 -scale-x-100", className)}
+      />
+    </span>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const GITHUB_URL = "https://github.com/lgtm-factory/lgtm-factory";


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号

<!-- 例: close #36 -->

close #122 

## やったこと（変更点）
- react-simple-iconsをインストール
- lib/constants.tsを作成し、`GITHUB_URL`を定数化
- ヘッダーとフッターを実装
  - `sticky`でヘッダーを上部に固定

## 動作確認
開発環境で確認済み
プレビュー画面：
https://a6d9e3e5.lgtm-factory.pages.dev/
<!-- どのような動作確認を行ったのか？　-->

## その他
コンポーネントの切り分け方のベストプラクティスがわからず、自己流です🤨
もっと良い書き方があれば、お手数ですがアドバイスいただけると幸いです……
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）　-->
