### PR TITLE
OG画像の設定

### DIFF
--- a/design-guide.md
+++ b/design-guide.md
@@ -183,10 +183,11 @@ LGTM Factory に、デザインテーマを追加する方法は、２通りあ�
 **その際、CSS の記述方法に応じて、下記のテンプレートを使用できます**:
 
 <details>
-  <summary>💡 テンプレート1: インラインスタイル</summary>
+  <summary><strong>💡 テンプレート1: インラインスタイル</strong></summary>
 
 ```tsx
 import { GetLgtmDataResult, InputData } from "@/types/lgtm-data";
+import { ImageResponseOptions } from "next/server";
 
 async function getLgtmData(inputData: InputData): Promise<GetLgtmDataResult> {
   const designInfo = {
@@ -195,7 +196,7 @@ async function getLgtmData(inputData: InputData): Promise<GetLgtmDataResult> {
     editableFields: ["emoji"],
   };
 
-  const options = {
+  const options: ImageResponseOptions = {
     width: 1200,
     height: 630,
     emoji: "twemoji",
@@ -244,10 +245,11 @@ export default getLgtmData;
 </details>
 
 <details>
-  <summary>💡 テンプレート2: Tailwind CSSによるスタイリング</summary>
+  <summary><strong>💡 テンプレート2: Tailwind CSSによるスタイリング</strong></summary>
 
 ```tsx
 import { GetLgtmDataResult, InputData } from "@/types/lgtm-data";
+import { ImageResponseOptions } from "next/server";
 
 async function getLgtmData(inputData: InputData): Promise<GetLgtmDataResult> {
   const designInfo = {
@@ -256,7 +258,7 @@ async function getLgtmData(inputData: InputData): Promise<GetLgtmDataResult> {
     editableFields: ["emoji"],
   };
 
-  const options = {
+  const options: ImageResponseOptions = {
     width: 1200,
     height: 630,
     emoji: "twemoji",
@@ -348,7 +350,7 @@ Webサイト上に掲載するため、必要なデザイン情報は、以下�
      style: 'normal' | 'italic'
   }
   ```
-  
+
 **テキストのフォントの種類について**:
 
 - テキストのフォントの種類は、現在`Google Fonts` のみをサポートしています。
@@ -364,13 +366,14 @@ Webサイト上に掲載するため、必要なデザイン情報は、以下�
     ],
   ```
 - `Google Fonts` のURLを取得する手順は、次の通りです：
+
 1. [Google Fonts](https://fonts.google.com)のサイト上から、お好きなフォントを選び、太さ（weight）を選択する
 2. 「**Get embed code**」ボタンをクリック
 3. `https://fonts.googleapis.com/css2`から始まる、フォントのURLをコピー
-    - **`Italic`や`Weight`は、Google Fonts のサイト上で指定してください**
-    - 例：`https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,700`
+   - **`Italic`や`Weight`は、Google Fonts のサイト上で指定してください**
+   - 例：`https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,700`
 4. ファイル内でインポートした、`getFontData()`の引数に渡す
-    - 🚨注意：`import getFontData from "@/utils/google-font";`で、フォント取得用の関数をインポートしてください。
+   - 🚨注意：`import getFontData from "@/utils/google-font";`で、フォント取得用の関数をインポートしてください。
 
 > [!IMPORTANT]
 > このテキストのフォントのカスタマイズについては、検証中の機能です。<br>

--- a/lgtm-data/opengraph.tsx
+++ b/lgtm-data/opengraph.tsx
@@ -1,0 +1,61 @@
+import { siteMetadata } from "@/lib/constants";
+import { GetLgtmDataResult, InputData } from "@/types/lgtm-data";
+import getFontData from "@/utils/google-font";
+import { ImageResponseOptions } from "next/server";
+
+async function getLgtmData(inputData: InputData): Promise<GetLgtmDataResult> {
+  const designInfo = {
+    author: "kazzyfrog",
+    description: "LGTM Factory の OpenGraph 画像です 📦",
+    editableFields: ["emoji"],
+  };
+
+  const options: ImageResponseOptions = {
+    width: 1200,
+    height: 630,
+    emoji: "twemoji",
+    fonts: [
+      {
+        name: "Monoton",
+        data: await getFontData(
+          "https://fonts.googleapis.com/css2?family=Monoton",
+        ),
+        weight: 400,
+      },
+    ],
+  };
+
+  const element = (
+    <div tw="flex h-full w-full flex-col items-center bg-white">
+      <div tw="flex h-screen absolute">
+        <img
+          src={`${siteMetadata.SITE_URL}/bg-dark.png`}
+          alt="paper-background"
+          width={1200}
+          height={630}
+        />
+      </div>
+      <div tw="w-[323px] h-[74px] bg-black rounded-full mt-[55px]" />
+      <div tw="flex mt-[35px]">
+        <img
+          src={`${siteMetadata.SITE_URL}/icon.svg`}
+          alt="logo"
+          width={512}
+          tw="mr-[56px] mt-[21px]"
+        />
+        <h1 tw="flex flex-col items-center text-white">
+          <span tw="text-[180px]">LGTM</span>
+          <span tw="top-[-84px] text-[102px]">Factory</span>
+        </h1>
+      </div>
+    </div>
+  );
+
+  return {
+    designInfo,
+    element,
+    options,
+  };
+}
+
+export default getLgtmData;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,13 @@ export const metadata: Metadata = {
     siteName: siteMetadata.SITE_NAME,
     locale: "ja_JP",
     type: "website",
+    images: [
+      {
+        url: "/api/v1/lgtm-images?theme=opengraph",
+        width: 1200,
+        height: 630,
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,7 +8,7 @@ interface SiteMetadata {
 }
 
 export const siteMetadata: SiteMetadata = {
-  SITE_URL: "https://lgtm-factory.pages.dev/",
+  SITE_URL: "https://lgtm-factory.pages.dev",
   SITE_NAME: "LGTM Factory",
   SITE_DESC:
     "HTML/CSSから生成されたフリーLGTM画像のコレクション | Free & Open Source LGTM Image Generator 📦",


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号
<!-- 例: close #36 -->
close #161

## やったこと（変更点）
<!-- このプルリクで何をしたのか？ -->

- OGP画像を、コーディングしました！
- 上記を、layout.tsx内のメタデータから、設定しました
    - Next.jsでは、Twitter画像を設定しない場合は、OG画像が流用される仕様です！
- その他、作成時にドキュメントの不備を見つけたので修正しました

また、デザインテーマのコードに関しては、ImageResponseの仕様で`<Image>`が使えません。
（`/icon.svg`のような内部相対パスが、デザイン内では使用できません。）
なので、`<img>`の記述をわかりやすくするため、`/`を削除しました！

これに関する、他の箇所への影響は、特にないと思います！👍

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->

OG画像の適用！

## 動作確認
<!-- どのような動作確認を行ったのか？　-->

生成されるファイルは、一通り確認しました！
あとは、マージ後に適用されているか、チェックしますー

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）　-->

画像パスなどの、開発時と本番・プレビューでのURLなどは、
別件で上がっていると思うので、そちらで調査＆対処していければと思います👍