### PR TITLE
利用規約ページの追加

### DIFF
--- a/src/app/(pages)/layout.tsx
+++ b/src/app/(pages)/layout.tsx
@@ -1,0 +1,16 @@
+import Header from "@/components/Header";
+import NewLGTMButton from "@/components/NewLGTMButton";
+
+export default function PageLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <>
+      <Header />
+      <main className="container">{children}</main>
+      <NewLGTMButton />
+    </>
+  );
+}

--- a/src/app/(pages)/page.tsx
+++ b/src/app/(pages)/page.tsx
@@ -1,10 +1,8 @@
 // "use client";
 // import { Button } from "@/components/shadcn-ui/button";
 import HeroSection from "@/components/HeroSection";
-import NewLGTMButton from "@/components/NewLGTMButton";
 import MainSection from "@/components/MainSection";
 import EditSheet from "@/components/EditSheet";
-
 
 export default function Home() {
   // function copy(copyText: string) {
@@ -15,13 +13,12 @@ export default function Home() {
   // const copyText = `[![LGTMeow](https://lgtm-images.lgtmeow.com/2022/05/10/23/8bb2a459-a0b5-4acc-970c-69ad8808f905.webp)](https://lgtmeow.com)`;
   // const url = "/api/v1/lgtm-images?theme=test";
   return (
-    <main className="container">
+    <>
       <EditSheet />
       <div className="my-16 space-y-16 md:my-20 md:space-y-20 lg:my-32 lg:space-y-32">
         <HeroSection />
         <MainSection />
       </div>
-      <NewLGTMButton />
       {/* <Button onClick={() => copy(copyText)}>copy</Button>
       <Button asChild>
         <a href={url} download="lgtm-image">
@@ -31,6 +28,6 @@ export default function Home() {
       <div className="text-4xl">
         <Image src={logoImage} width={180} alt="logo image" />
       </div> */}
-    </main>
+    </>
   );
 }

--- a/src/app/(pages)/terms/page.tsx
+++ b/src/app/(pages)/terms/page.tsx
@@ -1,0 +1,123 @@
+import { siteMetadata } from "@/lib/constants";
+
+export default function Terms() {
+  return (
+    <>
+      <div className="my-12 flex w-full">
+        <div className="w-full rounded-sm bg-white bg-opacity-50 p-16 leading-relaxed lg:w-3/4">
+          <h1 className="text-5xl font-semibold">ご利用について</h1>
+          <h2 className="mt-8 text-2xl font-semibold">はじめに</h2>
+          <p className="mt-4">
+            LGTM
+            Factory（以下「本サービス」）のご利用にあたっては、以下の規定をご確認ください👋
+          </p>
+          <p className="mt-4">要点：</p>
+          <ul className="mt-4 list-inside list-disc">
+            <li>
+              個人または商業的なプロジェクトで、無料で画像を使用できます。
+            </li>
+            <li>リンクまたはクレジット（引用元）の表記は任意です。</li>
+            <li>
+              画像自体をコンテンツや商品として複製・再配布・販売したりしないでください。
+            </li>
+          </ul>
+          <p className="mt-4 rounded-lg border border-gray-400 p-4">
+            また、利用規約の変更履歴は
+            <a
+              className="underline"
+              href={siteMetadata.GITHUB_URL}
+              target="_blank"
+            >
+              GitHub
+            </a>
+            で確認できます。
+            <br />
+            本サービスに関する提案・不明点については、GitHub上の
+            <a
+              className="underline"
+              href={`${siteMetadata.GITHUB_URL}/issues`}
+              target="_blank"
+            >
+              Issues
+            </a>
+            にてお問い合わせ下さい。
+          </p>
+
+          <h2 className="mt-8 text-2xl font-semibold">
+            1. 本サービスの利用目的
+          </h2>
+          <p className="mt-4">
+            本サービスは、HTMLとCSS、そしてフリー素材から生成された LGTM（Looks
+            Good To Me）画像を提供するオープンソースのプロジェクトです。
+            <br />
+            本サービスの第一の目的は、ユーザーがコードレビューやコミュニケーションを楽しく効果的に行えるようにすることです。
+          </p>
+
+          <h2 className="mt-8 text-2xl font-semibold">2. 画像の利用規定</h2>
+          <ol className="mt-4 list-inside list-decimal">
+            <li>
+              ユーザーは、規約の範囲内であれば、本サービスで提供される画像を、個人、法人、商用、非商用問わず無料で使用することができます。
+            </li>
+            <li>
+              画像使用時のリンクまたはクレジット（引用元）表記は任意です。表記する場合は、本サービスのリンクまたは「LGTM
+              Factory」としてください。
+            </li>
+            <li>著作権はLGTM Factoryに帰属し、放棄していません。</li>
+          </ol>
+
+          <h3 className="mt-4 font-semibold">画像の使用が禁止される場合：</h3>
+          <ul className="mt-4 list-inside list-disc">
+            <li>画像自体をコンテンツ・商品として再配布・販売</li>
+            <li>画像自体をメインのコンテンツとした使用</li>
+            <li>公序良俗に反する目的での利用</li>
+            <li>
+              本サービスまたは第三者に対する攻撃的・差別的・性的・過激な利用
+            </li>
+            <li>反社会的勢力や違法行為に関わる使用</li>
+            <li>その他運営者が不適切と判断した場合</li>
+          </ul>
+
+          <h2 className="mt-8 text-2xl font-semibold">3. その他の禁止事項</h2>
+          <ol className="mt-4 list-inside list-decimal">
+            <li>
+              過剰なリクエスト：サーバーに過度の負荷をかけるような大量のリクエストの送信
+            </li>
+            <li>
+              迷惑行為：本サービスの運営を妨げる行為や、他のユーザーに迷惑をかける行為
+            </li>
+          </ol>
+          <p className="mt-4">
+            上記を確認した場合、特定のユーザーに対して予告なくアクセスを禁止・制限することがあります。
+          </p>
+
+          <h2 className="mt-8 text-2xl font-semibold">4. 免責事項</h2>
+
+          <ol className="mt-4 list-inside list-decimal">
+            <li>
+              本サービスの使用及び閲覧は、ユーザーの責任において行うものとします。特定の目的への適合性や、エラーやバグがないことを保証するものではありません
+            </li>
+            <li>
+              本サービスの利用により生じた損害について、運営者は一切の責任を負いません。
+            </li>
+          </ol>
+
+          <h2 className="mt-8 text-2xl font-semibold">5. その他</h2>
+          <ol className="mt-4 list-inside list-decimal">
+            <li>
+              運営者は、事前の通知なく本サービスの内容を変更したり、サービスを一時的または永続的に停止したりする権利を有します。
+            </li>
+            <li>
+              運営者は、必要に応じて本規約を変更することがあり、変更後の規約は、本サービス上で公開された時点で効力を生じるものとします。
+            </li>
+            <li>
+              ユーザーは定期的に本規約を確認する責任があります。本サービスを利用し続けることで、変更後の規約にも同意したものとみなされます。
+            </li>
+          </ol>
+        </div>
+
+        {/* TODO: 画像を配置 */}
+        {/* <div className="sticky top-0 hidden h-screen w-1/4 flex-col items-center justify-center px-4 lg:flex"></div> */}
+      </div>
+    </>
+  );
+}

--- a/src/app/(pages)/terms/page.tsx
+++ b/src/app/(pages)/terms/page.tsx
@@ -1,18 +1,39 @@
 import { siteMetadata } from "@/lib/constants";
 
+const Heading = ({ children }: { children: React.ReactNode }) => (
+  <h2 className="pt-4 text-2xl font-semibold">{children}</h2>
+);
+
+const Alert = ({ children }: { children: React.ReactNode }) => (
+  <p className="rounded-lg border border-gray-400 p-4">{children}</p>
+);
+
+const List = ({
+  children,
+  type,
+}: {
+  children: React.ReactNode;
+  type: "ul" | "ol";
+}) =>
+  type === "ul" ? (
+    <ul className="list-inside list-disc">{children}</ul>
+  ) : (
+    <ol className="list-inside list-decimal">{children}</ol>
+  );
+
 export default function Terms() {
   return (
     <>
       <div className="my-12 flex w-full">
-        <div className="w-full rounded-sm bg-white bg-opacity-50 p-16 leading-relaxed lg:w-3/4">
+        <div className="w-full space-y-4 rounded-sm bg-white/50 p-16 leading-relaxed lg:w-3/4">
           <h1 className="text-5xl font-semibold">ご利用について</h1>
-          <h2 className="mt-8 text-2xl font-semibold">はじめに</h2>
-          <p className="mt-4">
+          <Heading>はじめに</Heading>
+          <p>
             LGTM
             Factory（以下「本サービス」）のご利用にあたっては、以下の規定をご確認ください👋
           </p>
-          <p className="mt-4">要点：</p>
-          <ul className="mt-4 list-inside list-disc">
+          <p>要点：</p>
+          <List type="ul">
             <li>
               個人または商業的なプロジェクトで、無料で画像を使用できます。
             </li>
@@ -20,8 +41,8 @@ export default function Terms() {
             <li>
               画像自体をコンテンツや商品として複製・再配布・販売したりしないでください。
             </li>
-          </ul>
-          <p className="mt-4 rounded-lg border border-gray-400 p-4">
+          </List>
+          <Alert>
             また、利用規約の変更履歴は
             <a
               className="underline"
@@ -41,20 +62,18 @@ export default function Terms() {
               Issues
             </a>
             にてお問い合わせ下さい。
-          </p>
+          </Alert>
 
-          <h2 className="mt-8 text-2xl font-semibold">
-            1. 本サービスの利用目的
-          </h2>
-          <p className="mt-4">
+          <Heading>1. 本サービスの利用目的</Heading>
+          <p>
             本サービスは、HTMLとCSS、そしてフリー素材から生成された LGTM（Looks
             Good To Me）画像を提供するオープンソースのプロジェクトです。
             <br />
             本サービスの第一の目的は、ユーザーがコードレビューやコミュニケーションを楽しく効果的に行えるようにすることです。
           </p>
 
-          <h2 className="mt-8 text-2xl font-semibold">2. 画像の利用規定</h2>
-          <ol className="mt-4 list-inside list-decimal">
+          <Heading>2. 画像の利用規定</Heading>
+          <List type="ol">
             <li>
               ユーザーは、規約の範囲内であれば、本サービスで提供される画像を、個人、法人、商用、非商用問わず無料で使用することができます。
             </li>
@@ -63,10 +82,9 @@ export default function Terms() {
               Factory」としてください。
             </li>
             <li>著作権はLGTM Factoryに帰属し、放棄していません。</li>
-          </ol>
-
-          <h3 className="mt-4 font-semibold">画像の使用が禁止される場合：</h3>
-          <ul className="mt-4 list-inside list-disc">
+          </List>
+          <h3 className="font-semibold">画像の使用が禁止される場合：</h3>
+          <List type="ul">
             <li>画像自体をコンテンツ・商品として再配布・販売</li>
             <li>画像自体をメインのコンテンツとした使用</li>
             <li>公序良俗に反する目的での利用</li>
@@ -75,34 +93,33 @@ export default function Terms() {
             </li>
             <li>反社会的勢力や違法行為に関わる使用</li>
             <li>その他運営者が不適切と判断した場合</li>
-          </ul>
+          </List>
 
-          <h2 className="mt-8 text-2xl font-semibold">3. その他の禁止事項</h2>
-          <ol className="mt-4 list-inside list-decimal">
+          <Heading>3. その他の禁止事項</Heading>
+          <List type="ol">
             <li>
               過剰なリクエスト：サーバーに過度の負荷をかけるような大量のリクエストの送信
             </li>
             <li>
               迷惑行為：本サービスの運営を妨げる行為や、他のユーザーに迷惑をかける行為
             </li>
-          </ol>
-          <p className="mt-4">
+          </List>
+          <p>
             上記を確認した場合、特定のユーザーに対して予告なくアクセスを禁止・制限することがあります。
           </p>
 
-          <h2 className="mt-8 text-2xl font-semibold">4. 免責事項</h2>
-
-          <ol className="mt-4 list-inside list-decimal">
+          <Heading>4. 免責事項</Heading>
+          <List type="ol">
             <li>
               本サービスの使用及び閲覧は、ユーザーの責任において行うものとします。特定の目的への適合性や、エラーやバグがないことを保証するものではありません
             </li>
             <li>
               本サービスの利用により生じた損害について、運営者は一切の責任を負いません。
             </li>
-          </ol>
+          </List>
 
-          <h2 className="mt-8 text-2xl font-semibold">5. その他</h2>
-          <ol className="mt-4 list-inside list-decimal">
+          <Heading>5. その他</Heading>
+          <List type="ol">
             <li>
               運営者は、事前の通知なく本サービスの内容を変更したり、サービスを一時的または永続的に停止したりする権利を有します。
             </li>
@@ -112,7 +129,7 @@ export default function Terms() {
             <li>
               ユーザーは定期的に本規約を確認する責任があります。本サービスを利用し続けることで、変更後の規約にも同意したものとみなされます。
             </li>
-          </ol>
+          </List>
         </div>
 
         {/* TODO: 画像を配置 */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { IBM_Plex_Mono, Noto_Sans_JP, Monoton } from "next/font/google";
 import "./globals.css";
 import { cn } from "@/lib/shadcn-utils";
-import Header from "@/components/Header";
 import { siteMetadata } from "@/lib/constants";
 
 export const metadata: Metadata = {
@@ -69,7 +68,6 @@ export default function RootLayout({
           "-z-10 bg-[url('/bg-dark.png')] bg-cover bg-fixed bg-center font-sans text-foreground",
         )}
       >
-        <Header />
         {children}
       </body>
     </html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,6 +25,8 @@ export default function Header() {
         </Link>
       </HeaderButton>
 
+      <Link href="/terms">License</Link>
+
       <HeaderButton>
         <a href={siteMetadata.GITHUB_URL} target="_blank">
           <SiGithub size={24} />


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号

<!-- 例: close #36 -->
close #148

## やったこと（変更点）
<!-- このプルリクで何をしたのか？ -->

- 規約ページの追加
- ヘッダーにもリンクを記載（ページはtermsですが、日本人にとってわかりずらいので、licenseにしました！日本語は合わなそうなので！もし、余裕があったら、他のデザインも合わせて日本語に合うように変えても良いかもです！日・英！）
- そのほか、ディレクトリ構成のリファクタリング：直接UIと関係するページを`(pages)`ファイル内にまとめました！（これによって、`app`内直下のメタデータ系のファイルは、特別な理由がない限り触らない、というふうに区別できるかと👍）

## やらないこと

<!-- このプルリクでやらないことは何か（やらない場合は、どのタイミングでやるかを記載（不明なら書かなくてOK）） -->

- ヘッダー全体のデザイン更新
- 規約ページの右側サイドバーが空いているので、画像などを配置しても良いかも！現状なしでも、問題ないですが！

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？ -->

このサービスのコアである、画像の利用を明確に示すことで、フリーで安心して使えるようにする！

## 動作確認

<!-- どのような動作確認を行ったのか？　-->

レスポンシブも一応対応させています！
基本的には、テキストベースのページなので、規約オペ時としての役目は果たすように見やすく整理したつもりです！
（将来的には、このページもデザインを少しリッチにしても良いかもです）
https://add-terms-page--148.lgtm-factory.pages.dev/terms

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）　-->
