### PR TITLE
TOPページの画像一覧のレイアウトを修正

### DIFF
--- a/lgtm-data/beer-glass.tsx
+++ b/lgtm-data/beer-glass.tsx
@@ -11,8 +11,8 @@ async function getLgtmData(inputData: InputData): Promise<GetLgtmDataResult> {
   };
 
   const options: ImageResponseOptions = {
-    width: 384,
-    height: 461,
+    width: 269,
+    height: 308,
     emoji: "noto",
     fonts: [
       {

--- a/src/components/ImageInfoModal.tsx
+++ b/src/components/ImageInfoModal.tsx
@@ -18,6 +18,7 @@ import LgtmImage from "@/components/LgtmImage";
 import { siteMetadata } from "@/lib/constants";
 import { DesignInfo } from "@/types/lgtm-data";
 import { useEffect, useState } from "react";
+import Image from "next/image";
 
 function ImageInfoModal({ theme }: { theme: string }) {
   const url = `${siteMetadata.SITE_URL}/api/v1/lgtm-images?theme=${theme}`;
@@ -46,7 +47,15 @@ function ImageInfoModal({ theme }: { theme: string }) {
   return (
     <Sheet>
       <SheetTrigger>
-        <LgtmImage theme={theme} className="cursor-pointer" />
+        <div className="flex h-full w-full cursor-pointer items-center hover:opacity-80 sm:aspect-square">
+          <Image
+            width={1200}
+            height={630}
+            src={`/api/v1/lgtm-images?theme=${theme}`}
+            alt={theme}
+            className="max-h-full max-w-full object-contain"
+          />
+        </div>
       </SheetTrigger>
       <SheetContent className="space-y-8 p-10">
         <SheetHeader>

--- a/src/components/MainSection.tsx
+++ b/src/components/MainSection.tsx
@@ -15,7 +15,7 @@ async function MainSection() {
 
   return (
     <section>
-      <div className="mx-auto grid w-fit gap-8 sm:grid-cols-2 sm:gap-14 lg:grid-cols-3">
+      <div className="mx-auto grid w-fit gap-x-3 gap-y-6 px-16 sm:grid-cols-2 sm:px-0 lg:grid-cols-4">
         {themes?.map((theme: string) => {
           return <ImageInfoModal theme={theme} key={theme} />;
         })}


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号

<!-- 例: close #36 -->

close #190

## やったこと（変更点）

<!-- このプルリクで何をしたのか？ -->

TOPページの画像一覧のレイアウトを修正しました！

加えて、
- 過去にサイズを修正したはずの、LGTM画像に修正漏れを見つけたので、ついでに修正しました！


## できるようになること（ユーザ目線）

<!-- 何ができるようになるのか？ -->

基本的に、正方形のボックスに、画像いっぱいで表示されるようになりました！
見栄えも考慮し、現状４カラムで表示しています👍


## 動作確認

<!-- どのような動作確認を行ったのか？　-->

現状は、以下のような表示です！（小さく、正方形のブロックで、シールっぽく配置しています！）

<img width="1440" alt="スクリーンショット 2024-09-06 21 43 56" src="https://github.com/user-attachments/assets/1096051f-8c93-46cb-8e1b-881ed912d8a8">

