### PR TITLE
perf: 🐎 #185 ImageInfoModalをSC化して、fetchをサーバーサイドで実行する

### DIFF
--- a/src/components/ImageForm.tsx
+++ b/src/components/ImageForm.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { siteMetadata } from "@/lib/constants";
+import CopyButton from "./CopyButton";
+import LgtmImage from "./LgtmImage";
+import DownloadButton from "./DownloadButton";
+import ShareButton from "./ShareButton";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { useState } from "react";
+import { Button } from "./shadcn-ui/button";
+import { DesignInfo } from "@/types/lgtm-data";
+import { Input } from "./shadcn-ui/input";
+
+function ImageForm({
+  theme,
+  info,
+}: {
+  theme: string;
+  info: DesignInfo | null;
+}) {
+  const [url, setUrl] = useState(`/api/v1/lgtm-images?theme=${theme}`);
+  const { register, handleSubmit, getValues } = useForm();
+  type Inputs = {
+    text?: string;
+    emoji?: string;
+    color?: string;
+  };
+  const onSubmit: SubmitHandler<Inputs> = (data) => {
+    const queryParams = new URLSearchParams({
+      text: data.text || "LGTM Factory",
+      emoji: data.emoji || "📦",
+      color: data.color || "#000000",
+    });
+
+    const newUrl = `/api/v1/lgtm-images?theme=${theme}&${queryParams}`;
+    setUrl(newUrl);
+  };
+  return (
+    <>
+      <LgtmImage url={url} />
+      <div className="flex gap-4">
+        <CopyButton url={`${siteMetadata.SITE_URL}${url}`} />
+        <DownloadButton url={`${siteMetadata.SITE_URL}${url}`} />
+      </div>
+      <ShareButton />
+      {info?.editableFields && info.editableFields.length > 0 && (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {info?.editableFields?.map((editableField: string) => (
+            <Input
+              key={editableField}
+              defaultValue={getValues(editableField)}
+              {...register(editableField)}
+              type="text"
+              placeholder={editableField}
+            />
+          ))}
+          <Button className="w-full" type="submit">
+            submit
+          </Button>
+        </form>
+      )}
+    </>
+  );
+}
+
+export default ImageForm;

--- a/src/components/ImageForm.tsx
+++ b/src/components/ImageForm.tsx
@@ -1,15 +1,15 @@
 "use client";
 
+import { useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
 import { siteMetadata } from "@/lib/constants";
-import CopyButton from "./CopyButton";
+import { DesignInfo } from "@/types/lgtm-data";
+import { Button } from "./shadcn-ui/button";
+import { Input } from "./shadcn-ui/input";
 import LgtmImage from "./LgtmImage";
+import CopyButton from "./CopyButton";
 import DownloadButton from "./DownloadButton";
 import ShareButton from "./ShareButton";
-import { SubmitHandler, useForm } from "react-hook-form";
-import { useState } from "react";
-import { Button } from "./shadcn-ui/button";
-import { DesignInfo } from "@/types/lgtm-data";
-import { Input } from "./shadcn-ui/input";
 
 function ImageForm({
   theme,

--- a/src/components/ImageInfoModal.tsx
+++ b/src/components/ImageInfoModal.tsx
@@ -7,29 +7,13 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/shadcn-ui/sheet";
-import { Input } from "@/components/shadcn-ui/input";
-import { Button } from "@/components/shadcn-ui/button";
-import CopyButton from "@/components/CopyButton";
-import DownloadButton from "@/components/DownloadButton";
-import ShareButton from "@/components/ShareButton";
-import LgtmImage from "@/components/LgtmImage";
 import { siteMetadata } from "@/lib/constants";
 import { DesignInfo } from "@/types/lgtm-data";
 import { useEffect, useState } from "react";
-import { useForm, SubmitHandler } from "react-hook-form";
 import Image from "next/image";
+import ImageForm from "./ImageForm";
 
 function ImageInfoModal({ theme }: { theme: string }) {
-  const { register, handleSubmit, getValues } = useForm();
-
-  const [url, setUrl] = useState(`/api/v1/lgtm-images?theme=${theme}`);
-
-  type Inputs = {
-    text?: string;
-    emoji?: string;
-    color?: string;
-  };
-
   const [info, setInfo] = useState<DesignInfo | null>(null);
 
   useEffect(() => {
@@ -51,17 +35,6 @@ function ImageInfoModal({ theme }: { theme: string }) {
     getDesignInfo(theme);
   }, [theme]);
 
-  const onSubmit: SubmitHandler<Inputs> = (data) => {
-    const queryParams = new URLSearchParams({
-      text: data.text || "LGTM Factory",
-      emoji: data.emoji || "📦",
-      color: data.color || "#000000",
-    });
-
-    const newUrl = `/api/v1/lgtm-images?theme=${theme}&${queryParams}`;
-    setUrl(newUrl);
-  };
-
   return (
     <Sheet>
       <SheetTrigger>
@@ -69,7 +42,7 @@ function ImageInfoModal({ theme }: { theme: string }) {
           <Image
             width={1200}
             height={630}
-            src={url}
+            src={`${siteMetadata.SITE_URL}/api/v1/lgtm-images?theme=${theme}`}
             alt={theme}
             className="max-h-full max-w-full object-contain"
           />
@@ -84,28 +57,7 @@ function ImageInfoModal({ theme }: { theme: string }) {
             <li>editableFields: {info?.editableFields?.join(", ")}</li>
           </ul>
         </SheetHeader>
-        <LgtmImage url={url} />
-        <div className="flex gap-4">
-          <CopyButton url={`${siteMetadata.SITE_URL}${url}`} />
-          <DownloadButton url={`${siteMetadata.SITE_URL}${url}`} />
-        </div>
-        <ShareButton />
-        {info?.editableFields && info.editableFields.length > 0 && (
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            {info?.editableFields?.map((editableField: string) => (
-              <Input
-                key={editableField}
-                defaultValue={getValues(editableField)}
-                {...register(editableField)}
-                type="text"
-                placeholder={editableField}
-              />
-            ))}
-            <Button className="w-full" type="submit">
-              submit
-            </Button>
-          </form>
-        )}
+        <ImageForm theme={theme} info={info} />
       </SheetContent>
     </Sheet>
   );

--- a/src/components/ImageInfoModal.tsx
+++ b/src/components/ImageInfoModal.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+import { siteMetadata } from "@/lib/constants";
 import {
   Sheet,
   SheetContent,
@@ -5,8 +7,6 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/shadcn-ui/sheet";
-import { siteMetadata } from "@/lib/constants";
-import Image from "next/image";
 import ImageForm from "./ImageForm";
 
 async function ImageInfoModal({ theme }: { theme: string }) {

--- a/src/components/ImageInfoModal.tsx
+++ b/src/components/ImageInfoModal.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Sheet,
   SheetContent,
@@ -8,32 +6,14 @@ import {
   SheetTrigger,
 } from "@/components/shadcn-ui/sheet";
 import { siteMetadata } from "@/lib/constants";
-import { DesignInfo } from "@/types/lgtm-data";
-import { useEffect, useState } from "react";
 import Image from "next/image";
 import ImageForm from "./ImageForm";
 
-function ImageInfoModal({ theme }: { theme: string }) {
-  const [info, setInfo] = useState<DesignInfo | null>(null);
-
-  useEffect(() => {
-    async function getDesignInfo(theme: string) {
-      try {
-        const response = await fetch(
-          `${siteMetadata.SITE_URL}/api/v1/design-info?theme=${theme}`,
-        );
-        const { designInfo } = await response.json();
-        setInfo(designInfo);
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          console.error(`fetch error: ${error.message}`);
-          setInfo(null);
-        }
-      }
-    }
-
-    getDesignInfo(theme);
-  }, [theme]);
+async function ImageInfoModal({ theme }: { theme: string }) {
+  const response = await fetch(
+    `${siteMetadata.SITE_URL}/api/v1/design-info?theme=${theme}`,
+  );
+  const { designInfo: info } = await response.json();
 
   return (
     <Sheet>

--- a/src/components/ImageInfoModal.tsx
+++ b/src/components/ImageInfoModal.tsx
@@ -6,12 +6,9 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
-  SheetFooter,
-  SheetClose,
 } from "@/components/shadcn-ui/sheet";
 import { Input } from "@/components/shadcn-ui/input";
 import { Button } from "@/components/shadcn-ui/button";
-import { FormField } from "@/components/shadcn-ui/form";
 import CopyButton from "@/components/CopyButton";
 import DownloadButton from "@/components/DownloadButton";
 import ShareButton from "@/components/ShareButton";
@@ -23,7 +20,7 @@ import { useForm, SubmitHandler } from "react-hook-form";
 import Image from "next/image";
 
 function ImageInfoModal({ theme }: { theme: string }) {
-  const { register, handleSubmit, setValue, getValues } = useForm();
+  const { register, handleSubmit, getValues } = useForm();
 
   const [url, setUrl] = useState(`/api/v1/lgtm-images?theme=${theme}`);
 
@@ -95,17 +92,15 @@ function ImageInfoModal({ theme }: { theme: string }) {
         <ShareButton />
         {info?.editableFields && info.editableFields.length > 0 && (
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            {info?.editableFields?.map(
-              (editableField: string, index: number) => (
-                <Input
-                  key={editableField}
-                  defaultValue={getValues(editableField)}
-                  {...register(editableField)}
-                  type="text"
-                  placeholder={editableField}
-                />
-              ),
-            )}
+            {info?.editableFields?.map((editableField: string) => (
+              <Input
+                key={editableField}
+                defaultValue={getValues(editableField)}
+                {...register(editableField)}
+                type="text"
+                placeholder={editableField}
+              />
+            ))}
             <Button className="w-full" type="submit">
               submit
             </Button>


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号

<!-- 例: close #36 -->

close #185 

## やったこと（変更点）
- 使っていないモジュールの削除
- `ImageInfoModal`コンポーネントからフォーム部分を切り出し
- `ImageInfoModal`コンポーネントのSC化

<!-- このプルリクで何をしたのか？ -->

## やらないこと

- /api/v1/design-info/route.tsxをSG化する
	- 上記は当初実装予定でしたが、様々な理由（参考： #194 ）により、一旦なしとなりました
- 現在CloudflareにSG Routeをデプロイするとエラーが発生するので、今後SG Routeが使用可能となれば https://github.com/lgtm-factory/lgtm-factory/discussions/194#discussioncomment-10581132 を参考にSG Routeを実装する

<!-- このプルリクでやらないことは何か（やらない場合は、どのタイミングでやるかを記載（不明なら書かなくてOK）） -->

## できるようになること（ユーザ目線）
サーバーサイドで`design-info`の`fetch`が行われるため、処理速度が向上する

<!-- 何ができるようになるのか？ -->

<!-- 何ができなくなるのか？-->

## 動作確認
devツールのネットワークタブにて、ページ更新時に`design-info`の`fetch`が行われていないことを確認
<!-- どのような動作確認を行ったのか？　-->
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）　-->
