### PR TITLE
metadataでmask-iconを指定する

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,13 @@ export const metadata: Metadata = {
     title: siteMetadata.SITE_NAME,
     description: siteMetadata.SITE_DESC,
   },
+  icons: {
+    other: {
+      rel: "mask-icon",
+      url: "/icon.svg",
+      color: "#3f3f46",
+    },
+  },
 };
 
 const ibmMono = IBM_Plex_Mono({
@@ -61,9 +68,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <Head>
-        <link rel="mask-icon" href="/icon.svg" color="#3f3f46" />
-      </Head>
       <body
         className={cn(
           ibmMono.variable,


### PR DESCRIPTION
<!-- 全項目を埋める必要はないです！不要な場合は項目を削除/必要であれば項目追加してください！ -->

## 関連イシュー番号

<!-- 例: close #36 -->

close #204 

## やったこと（変更点）
- next/headでのmask-iconの指定部分を削除
- https://nextjs.org/docs/app/api-reference/functions/generate-metadata#icons を参考に、metadataでmask-iconを指定

## 動作確認
開発環境にて、Safariでの確認を行いました

<!-- どのような動作確認を行ったのか？　-->